### PR TITLE
Add static stage2 routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ active, the extension will be called independent of whether the line is currentl
 So please note that stage2 needs a particular configuration of the `cdrbuild` and `register` module in Yate to
 work correctly. See instructions below.
 
+### Static target routing
+
+Stage2 routing also supports static routing targets in addition to regular SIP users. Static routing targets can
+be used to dynamically configure extensions that are not a SIP client but rather a special yate call target like
+`conf/` or (most prominently) `external/`. In order to use static call routing, create an entry in the `users` table
+of stage2 routing with `type` being `static` instead of (the default) `user`. Put the yate call target into 
+`static_target`. You may use the syntax
+```
+external/nodata//opt/script.tcl arg1 arg2;myparam=myvalue;…
+```
+to popuate the semicolon separated `key=value` pairs into the `call.route`/`call.execute` message.
+
 ## Getting started
 
 Ywsd uses a PostgeSQL database backend that is accessed via the asyncio aiopg module. As a consequence, a minimal test

--- a/ywsd/objects.py
+++ b/ywsd/objects.py
@@ -52,6 +52,11 @@ class User:
         ),
         sa.Column("trunk", sa.Boolean, nullable=False, server_default="0"),
         sa.Column("call_waiting", sa.Boolean, nullable=False, server_default="1"),
+        sa.Column("static_target", sa.String(1024), nullable=False, server_default=""),
+        sa.CheckConstraint(
+            "(password != '') OR (type != 'user')",
+            name="sip_users_have_password",
+        ),
     )
 
     FIELDS_PLAIN = (
@@ -62,6 +67,7 @@ class User:
         "type",
         "trunk",
         "call_waiting",
+        "static_target",
     )
     FIELDS_TRANSFORM = (
         (


### PR DESCRIPTION
Applications need to call special yate targets such as the external/
module. This was only possible via a special entry in yate's
regexroute.conf. This patch adds a user type "static" to the stage2
routing tables with a static routing target. The stage2 routing will
then not do a SIP lookup for the user but rather directly call the
static target.