### PR TITLE
use short_name for all extension types if set

### DIFF
--- a/ywsd/routing_tree.py
+++ b/ywsd/routing_tree.py
@@ -95,7 +95,7 @@ class RoutingTree:
         if self.target.name is not None:
             parameters["calledname"] = self.target.name
 
-        if (self.target.short_name is not None):
+        if self.target.short_name is not None:
             # Callername should always be populated by source parameters, otherwise, default to source name
             callername = self._source_params.get("callername", self.source.name)
             parameters["callername"] = "[{}] {}".format(

--- a/ywsd/routing_tree.py
+++ b/ywsd/routing_tree.py
@@ -95,10 +95,7 @@ class RoutingTree:
         if self.target.name is not None:
             parameters["calledname"] = self.target.name
 
-        if (
-            self.target.type == Extension.Type.GROUP
-            and self.target.short_name is not None
-        ):
+        if (self.target.short_name is not None):
             # Callername should always be populated by source parameters, otherwise, default to source name
             callername = self._source_params.get("callername", self.source.name)
             parameters["callername"] = "[{}] {}".format(


### PR DESCRIPTION
the infodesk asked fo an indication if someone called an extension which is forwarded to them - we can now support this by manually adding the short_name to the forwarding extension