### PR TITLE
Stage1: Fix empty outgoing_name

### DIFF
--- a/ywsd/stage1.py
+++ b/ywsd/stage1.py
@@ -43,14 +43,15 @@ class RoutingTask:
 
     @staticmethod
     def calculate_source_parameters(source: Extension):
-        # push parameters here like faked-caller-id or caller-language
-        source_parameters = {}
+        # avoid name spoofing and push parameters here like faked-caller-id or caller-language
+        source_parameters = {
+            "callername": source.name,
+        }
         if source.outgoing_extension is not None and source.outgoing_extension != "":
             source_parameters["caller"] = source.outgoing_extension
-            source_parameters["callername"] = source.outgoing_name
-        else:
-            # avoid name spoofing
-            source_parameters["callername"] = source.name
+            # if there is a faked-callername set, apply it, otherwise we keep the original one
+            if source.outgoing_name is not None and source.outgoing_name != "":
+                source_parameters["callername"] = source.outgoing_name
         if source.lang is not None:
             source_parameters["osip_X-Caller-Language"] = source.lang
         if source.dialout_allowed:


### PR DESCRIPTION
If a faked caller id is set via outgoing_extension in the database entry for
a source extension and no outgoing_name is set, the callername was populated
with None. The yate message serializer doesn't like that. So, we check for
this scenario and keep the original callername in this case.