### PR TITLE
Fix forward to no route targets

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ aiopg
 aioredis
 python-yate
 pyyaml
-sqlalchemy
+sqlalchemy<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, "README.md"), "r") as f:
 
 setup(
     name="ywsd",
-    version="0.12.2",
+    version="0.13.0",
     packages=["ywsd"],
     url="https://gitlab.rc5.de/eventphone/ywsd",
     license="AGPLv3+",
@@ -22,6 +22,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     ],
     install_requires=[

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -116,6 +116,26 @@ async def write_testdata(conn):
                     "lang": "de_DE",
                     "ringback": None,
                 },
+                {
+                    "yate_id": None,
+                    "extension": "4000",
+                    "name": "Empty Group",
+                    "type": "GROUP",
+                    "forwarding_mode": "DISABLED",
+                    "forwarding_delay": None,
+                    "lang": "de_DE",
+                    "ringback": None,
+                },
+                {
+                    "yate_id": yates["sip"],
+                    "extension": "4001",
+                    "name": "I Forward to empty group",
+                    "type": "SIMPLE",
+                    "forwarding_mode": "DISABLED",
+                    "forwarding_delay": 10,
+                    "lang": "de_DE",
+                    "ringback": None,
+                },
             ]
         )
     )
@@ -133,6 +153,11 @@ async def write_testdata(conn):
         Extension.table.update()
         .where(Extension.table.c.extension == "2098")
         .values({"forwarding_extension_id": exts["2005"], "forwarding_mode": "ENABLED"})
+    )
+    await conn.execute(
+        Extension.table.update()
+        .where(Extension.table.c.extension == "4001")
+        .values({"forwarding_extension_id": exts["4000"], "forwarding_mode": "ENABLED"})
     )
 
     await conn.execute(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py38,py39,py310,py311
 skip_missing_interpreters = true
 
 


### PR DESCRIPTION
Delayed forwards cause another fork rank to be created. However, it might be that the forward target isn't reachable and has no route. In this case, the forward should be dropped and not added as fork rank. This commit fixes this and adds a regression test.