### PR TITLE
External auth bypass

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, "README.md"), "r") as f:
 
 setup(
     name="ywsd",
-    version="0.13.1",
+    version="0.13.2",
     packages=["ywsd"],
     url="https://gitlab.rc5.de/eventphone/ywsd",
     license="AGPLv3+",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312
 skip_missing_interpreters = true
 
 
@@ -9,6 +9,7 @@ log_cli = true
 deps =
     pytest
     pytest-black
+    black<=23.6.0
     pytest-asyncio
     docker
 commands = pytest --black {posargs}

--- a/ywsd/stage1.py
+++ b/ywsd/stage1.py
@@ -29,7 +29,10 @@ class RoutingTask:
             except DoesNotExist:
                 # this caller doesn't exist in our database, create an external extension
                 return Extension.create_external(caller)
-
+            if caller_extension.type == Extension.Type.EXTERNAL:
+                # this is an external extension that we also explicitly have in our db,
+                # return it similar to the on-the-fly created external extension
+                return caller_extension
             if (
                 self._message.params.get("connection_id")
                 in self._yate.settings.TRUSTED_LOCAL_LISTENERS


### PR DESCRIPTION
Bypass mandatory user authentication if the extension is of type external. This fixes dial-in from phone numbers that have been explicitly created as EXTERNAL extension in the routing tables.