### PR TITLE
Update redis engine & add busy cache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 aiopg
-aioredis
 python-yate
 pyyaml
 sqlalchemy<2.0.0
+redis[hiredis]

--- a/routing_engine.example.yaml
+++ b/routing_engine.example.yaml
@@ -25,11 +25,18 @@ INTERNAL_YATE_LISTENER: voip
 #TRUSTED_LOCAL_LISTENERS:
 #  - internal_udp
 
+# Uncomment to enable redis connection for redis-based caches
+# REDIS: "unix:///run/redis/redis.sock"
+
 CACHE_IMPLEMENTATION: "ywsd.routing_cache.PythonDictRoutingCache"
 #CACHE_IMPLEMENTATION: "ywsd.routing_cache.RedisRoutingCache"
 
+# Uncomment the following line to enable internal busy cache instead of yate-based in db.
+# BUSY_CACHE_IMPLEMENTATION: "ywsd.busy_cache.PythonDictBusyCache"
+# BUSY_CACHE_IMPLEMENTATION: "ywsd.busy_cache.RedisBusyCache"
+
+
 #CACHE_CONFIG:
-#  address: "/run/redis/redis.sock"
 #  object_lifetime: 600
 
 # Add a logfile here if you want file logging instead of stdout logging

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         "console_scripts": [
             "ywsd_init_db=ywsd.objects:main",
             "ywsd_engine=ywsd.engine:main",
+            "ywsd_busy_cache=ywsd.busy_cache:main",
         ],
     },
+    extra_require={"redis": ["redis[hiredis]"]},
 )

--- a/tests/test_ywsd_yate.py
+++ b/tests/test_ywsd_yate.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -139,6 +140,13 @@ async def test_ywsd_full_routing_with_stage2(ywsd_engine_ysim):
 @pytest.mark.usefixtures("ywsd_engine_ysim")
 async def test_ywsd_full_routing_with_stage2_no_callwaiting(ywsd_engine_ysim):
     engine, yate_sim = ywsd_engine_ysim
+
+    # we inform the internal busy cache that 2042 is on a call
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    result = await yate_sim.submit_message(msg)
+    assert not result.processed
+    # unfortunately the routing engine processes this asynchronously, we need to artificially wait here for completion
+    await asyncio.sleep(0.5)
 
     msg = MessageRequest("call.route", {"caller": "4748", "called": "2042"})
     result = await yate_sim.submit_message(msg)

--- a/tests/test_zbusy_cache.py
+++ b/tests/test_zbusy_cache.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import pytest
+
+from yate.protocol import MessageRequest
+
+# Please note that this testfile is called zbusy cache because the ywsd_web test suite has a test case
+# to test database initialization. However, this test case needs to run before all other tests as
+# otherwise the testdata set cannot be ingested into the database.
+# This is probably not the most elegant solution but works for now.
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_busy_cache_empty(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+    assert len(await engine.busy_cache.busy_status()) == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_busy_extension(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(
+        0.2
+    )  # ywsd processes this asynchronously. Give the other async task a chance to complete here
+    assert await engine.busy_cache.is_busy("2042")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_extension_was_busy(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(
+        0.2
+    )  # ywsd processes this asynchronously. Give the other async task a chance to complete here
+    msg = MessageRequest("call.cdr", {"operation": "finalize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+    assert await engine.busy_cache.is_busy("2042") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_busy_extension_when_call_knocking(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(
+        0.2
+    )  # ywsd processes this asynchronously. Give the other async task a chance to complete here
+    # another call knocks
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+    # first call is finished
+    msg = MessageRequest("call.cdr", {"operation": "finalize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+    # Extension should still be busy
+    assert await engine.busy_cache.is_busy("2042")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_extension_free_when_all_calls_finalized(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(
+        0.2
+    )  # ywsd processes this asynchronously. Give the other async task a chance to complete here
+    # another call knocks
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+    # first call is finished
+    msg = MessageRequest("call.cdr", {"operation": "finalize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+    # second call is finished
+    msg = MessageRequest("call.cdr", {"operation": "finalize", "external": "2042"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(0.2)
+
+    assert await engine.busy_cache.is_busy("2042") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("ywsd_engine_ysim")
+async def test_ywsd_extension_free_when_other_busy(ywsd_engine_ysim):
+    engine, yate_sim = ywsd_engine_ysim
+
+    msg = MessageRequest("call.cdr", {"operation": "initialize", "external": "2024"})
+    await yate_sim.submit_message(msg)
+    await asyncio.sleep(
+        0.2
+    )  # ywsd processes this asynchronously. Give the other async task a chance to complete here
+    assert await engine.busy_cache.is_busy("2042") is False

--- a/tests/testdata/test_config.yaml
+++ b/tests/testdata/test_config.yaml
@@ -22,6 +22,8 @@ INTERNAL_YATE_LISTENER: voip
 
 CACHE_IMPLEMENTATION: "ywsd.routing_cache.PythonDictRoutingCache"
 
+BUSY_CACHE_IMPLEMENTATION: "ywsd.busy_cache.PythonDictBusyCache"
+
 # Add a logfile here if you want file logging instead of stdout logging
 LOG_FILE:
 LOG_VERBOSE:

--- a/tests/yatesim.py
+++ b/tests/yatesim.py
@@ -1,5 +1,4 @@
 import asyncio
-import bisect
 from collections import defaultdict
 from datetime import datetime
 import logging

--- a/ywsd/busy_cache.py
+++ b/ywsd/busy_cache.py
@@ -1,0 +1,150 @@
+import asyncio
+from collections import defaultdict
+from typing import Dict
+import logging
+from yate.protocol import Message
+
+from .util import class_from_dotted_string
+
+try:
+    import redis.asyncio as redis
+except ImportError:
+    pass  # this is an optional dependency
+
+
+class BusyCacheBase:
+    def __init__(self, yate, settings):
+        self._yate = yate
+        self._settings = settings
+
+    async def init(self, skip_msg_registration=False, **kwargs):
+        if not skip_msg_registration:
+            await self._yate.register_message_handler_async(
+                "call.cdr", self._handle_cdr_message, priority=5
+            )
+
+    async def stop(self):
+        pass
+
+    def _handle_cdr_message(self, msg: Message):
+        if not "operation" in msg.params:
+            self._yate.answer_message(msg, False)
+        # we don't let yate wait until we processed thiss
+        self._yate.answer_message(msg, False)
+        asyncio.create_task(self._handle_msg_task(msg))
+
+    async def _handle_msg_task(self, msg: Message):
+        extension = msg.params.get("external")
+        if extension is None:
+            return
+        if msg.params["operation"] == "initialize":
+            await self._cdr_init(extension)
+        elif msg.params["operation"] == "finalize":
+            await self._cdr_finalize(extension)
+
+    async def is_busy(self, extension) -> bool:
+        pass
+
+    async def busy_status(self) -> Dict[str, int]:
+        pass
+
+    async def flush(self):
+        pass
+
+    async def _cdr_init(self, extension):
+        pass
+
+    async def _cdr_finalize(self, extension):
+        pass
+
+
+class PythonDictBusyCache(BusyCacheBase):
+    def __init__(self, yate, settings):
+        super().__init__(yate, settings)
+        self._cache = defaultdict(lambda: 0)
+
+    async def _cdr_init(self, extension):
+        self._cache[extension] += 1
+        logging.debug("Extension %s -> call.cdr init", extension)
+
+    async def _cdr_finalize(self, extension):
+        if self._cache[extension] > 0:
+            self._cache[extension] -= 1
+            logging.debug("Extension %s -> call.cdr finalize", extension)
+
+    async def is_busy(self, extension):
+        return self._cache[extension] > 0
+
+    async def busy_status(self):
+        return self._cache
+
+
+class RedisBusyCache(BusyCacheBase):
+    def __init__(self, yate, settings):
+        super().__init__(yate, settings)
+
+    async def _cdr_init(self, extension):
+        async with redis.Redis(connection_pool=self._yate.redis_pool) as client:
+            await client.hincrby("busy_cache", extension, 1)
+        logging.debug("Extension %s -> call.cdr init", extension)
+
+    async def _cdr_finalize(self, extension):
+        async with redis.Redis(connection_pool=self._yate.redis_pool) as client:
+            await client.hincrby("busy_cache", extension, -1)
+        logging.debug("Extension %s -> call.cdr finzalize", extension)
+
+    async def is_busy(self, extension):
+        async with redis.Redis(connection_pool=self._yate.redis_pool) as client:
+            status = await client.hget("busy_cache", extension)
+            return status is not None and int(status) > 0
+
+    async def busy_status(self):
+        async with redis.Redis(connection_pool=self._yate.redis_pool) as client:
+            return {
+                k.decode("ascii"): int(v)
+                for k, v in (await client.hgetall("busy_cache")).items()
+            }
+
+    async def flush(self):
+        async with redis.Redis(connection_pool=self._yate.redis_pool) as client:
+            await client.delete("busy_cache")
+
+
+def main():
+    asyncio.run(amain())
+
+
+async def amain():
+    import argparse
+    import ywsd.settings
+
+    parser = argparse.ArgumentParser(description="Yate Routing Engine Busy Cache")
+    parser.add_argument(
+        "--config", type=str, help="Config file to use.", default="routing_engine.yaml"
+    )
+    parser.add_argument(
+        "--flush", help="Drop tables if they already exist", action="store_true"
+    )
+
+    args = parser.parse_args()
+    settings = ywsd.settings.Settings(args.config)
+
+    if settings.BUSY_CACHE_IMPLEMENTATION is None:
+        logging.info("No busy cache configured. Exiting")
+        return
+
+    class MockYate:
+        redis_pool = None
+
+    yate = MockYate()
+    if settings.REDIS is not None:
+        yate.redis_pool = redis.ConnectionPool.from_url(settings.REDIS)
+
+    busy_cache = class_from_dotted_string(settings.BUSY_CACHE_IMPLEMENTATION)(
+        yate, settings
+    )
+    await busy_cache.init(skip_msg_registration=True)
+
+    if args.flush:
+        await busy_cache.flush()
+        logging.info("Busy cache flushed.")

--- a/ywsd/engine.py
+++ b/ywsd/engine.py
@@ -3,6 +3,7 @@ from typing import Optional, Dict
 import argparse
 import asyncio
 import logging
+import os
 import signal
 import traceback
 
@@ -45,6 +46,8 @@ class YateRoutingEngine(YateAsync):
         else:
             self._web_app = None
 
+        self.set_termination_handler(self.termination_handler)
+
     @property
     def settings(self):
         return self._settings
@@ -68,6 +71,12 @@ class YateRoutingEngine(YateAsync):
     @property
     def busy_cache(self):
         return self._busy_cache_engine
+
+    @staticmethod
+    def termination_handler():
+        # shutdown hard when connection to yate is lost
+        logging.error("Connection to yate lost. Terminating.")
+        os._exit(1)
 
     def run(self):
         if self._web_only:

--- a/ywsd/settings.py
+++ b/ywsd/settings.py
@@ -6,6 +6,7 @@ class Settings:
     _default_map = {
         "TRUSTED_LOCAL_LISTENERS": [],
         "ROUTING_TIME_WARNING_THRESHOLD_MS": 1000,
+        "CACHE_CONFIG": {},
     }
 
     def __init__(self, config_file=None):


### PR DESCRIPTION
This change adds an-ywsd based busy cache with python and/or redis storage backend. This is an attempt to figure out why we used to have problems with eternally busy extensions in the past. Data is being used from call.cdr messages - just like the yate-based line tracker.

Busy status of the internal cache can also be retrieved via the web interface at /busy_cache.

As aioredis is not supported any longer and support for asyncio has been moved into the main redis-py package, update all redis-based storage to the newer interface.