### PR TITLE
fix bug not printing the stacktrace in the log

### DIFF
--- a/ywsd/stage1.py
+++ b/ywsd/stage1.py
@@ -130,7 +130,7 @@ class RoutingTask:
                 raise  # this is a database error and the routing will be re-tried
             backtrace = traceback.format_exc()
             logging.error(
-                "An error occurred while routing {} to {}: {}\nBacktrace:".format(
+                "An error occurred while routing {} to {}: {}\nBacktrace:\n{}".format(
                     caller, called, e, backtrace
                 )
             )


### PR DESCRIPTION
When a non-db error occurs during stage1_routing the error message does not contain the stacktrace.
This PR fixes this